### PR TITLE
MCS-520: Updates to previously ingested data

### DIFF
--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -142,11 +142,11 @@ def ingest_scene_files(folder: str, eval_name: str, performer: str) -> None:
             scene["test_num"] = int(scene["name"][-6:-2])
             scene["scene_num"] = int(scene["name"][-1:])
         else:
+            scene["scene_num"] = scene["sceneNumber"]
             if "sequenceNumber" in scene:
                 scene["test_num"] = scene["sequenceNumber"]
             else:
                 scene["test_num"] = scene["hypercubeNumber"]
-            scene["scene_num"] = scene["sceneNumber"]
             if "sequenceId" in scene["goal"]["sceneInfo"]:
                 scene["goal"]["sceneInfo"]["hypercubeId"] = scene["goal"]["sceneInfo"]["sequenceId"]
                 del scene["goal"]["sceneInfo"]["sequenceId"]

--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -143,13 +143,16 @@ def ingest_scene_files(folder: str, eval_name: str, performer: str) -> None:
             scene["scene_num"] = int(scene["name"][-1:])
         else:
             scene["scene_num"] = scene["sceneNumber"]
+
             if "sequenceNumber" in scene:
                 scene["test_num"] = scene["sequenceNumber"]
             else:
                 scene["test_num"] = scene["hypercubeNumber"]
+
             if "sequenceId" in scene["goal"]["sceneInfo"]:
                 scene["goal"]["sceneInfo"]["hypercubeId"] = scene["goal"]["sceneInfo"]["sequenceId"]
                 del scene["goal"]["sceneInfo"]["sequenceId"]
+
         scene = delete_keys_from_scene(scene, KEYS_TO_DELETE)
         ingest_scenes.append(scene)
 

--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -182,8 +182,6 @@ def ingest_history_files(folder: str, eval_name: str, performer: str, scene_fold
             history_item["test_type"] = history_item["name"][:-7]
             history_item["test_num"] = int(history_item["name"][-6:-2])
             history_item["scene_num"] = int(history_item["name"][-1:])
-            history_item["url_string"] = ("eval=" + history_item["eval"] + "&test_type=" + history_item["test_type"] +
-                                         "&test_num=" + str(history_item["test_num"]) + "&scene=" + str(history_item["scene_num"]))
         else: 
             history_item["performer"] = TEAM_MAPPING_DICT[history["info"]["team"]]
             history_item["name"] = history["info"]["name"]
@@ -265,8 +263,6 @@ def ingest_history_files(folder: str, eval_name: str, performer: str, scene_fold
                         history_item["category_type"] = scene["goal"]["sceneInfo"]["name"][:-3]
                     else:
                         history_item["category_type"] = scene["goal"]["sceneInfo"]["tertiaryType"]
-                    history_item["url_string"] = ("eval=" + history_item["eval"] + "&category_type=" + history_item["category_type"] +
-                        "&test_num=" + str(history_item["test_num"]) + "&scene=" + str(history_item["scene_num"]))
                 # For eval 2 
                 else:
                     if("observation" in scene):

--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -147,6 +147,9 @@ def ingest_scene_files(folder: str, eval_name: str, performer: str) -> None:
             else:
                 scene["test_num"] = scene["hypercubeNumber"]
             scene["scene_num"] = scene["sceneNumber"]
+            if "sequenceId" in scene["goal"]["sceneInfo"]:
+                scene["goal"]["sceneInfo"]["hypercubeId"] = scene["goal"]["sceneInfo"]["sequenceId"]
+                del scene["goal"]["sceneInfo"]["sequenceId"]
         scene = delete_keys_from_scene(scene, KEYS_TO_DELETE)
         ingest_scenes.append(scene)
 

--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -15,7 +15,7 @@ mongoDB = client['mcs']
 
 # Currently just removing image mag from scene files, might wish to move more keys, 
 #    or remove so much from the schema that we want to just map the fields we want to the schema
-KEYS_TO_DELETE = ['image']
+KEYS_TO_DELETE = ['image', 'sequenceNumber', 'hypercubeNumber', 'sceneNumber']
 
 SCENE_INDEX = "mcs_scenes"
 HISTORY_INDEX = "mcs_history"

--- a/update_scene_num_refs.py
+++ b/update_scene_num_refs.py
@@ -1,0 +1,181 @@
+import argparse
+import cmd
+import os
+import io
+import json
+
+from collections.abc import MutableMapping 
+from pymongo import MongoClient
+from bson.objectid import ObjectId
+import copy
+
+HISTORY_INDEX = "mcs_history"
+SCENE_INDEX = "mcs_scenes"
+COLL_KEYS_INDEX = "collection_keys"
+EVAL_3_RESULTS = "Evaluation 3 Results"
+EVAL_2_RESULTS = "Evaluation 2 Results"
+EVAL_3_SCENES = "Evaluation 3 Scenes"
+EVAL_2_SCENES = "Evaluation 2 Scenes"
+
+# We might want to move mongo user/pass to new file
+client = MongoClient('mongodb://mongomcs:mongomcspassword@localhost:27017/mcs')
+mongoDB = client['mcs']
+
+def update_scene_num_refs_history_eval_3():
+    print("Begin Processing " + EVAL_3_RESULTS)
+    collection = mongoDB[HISTORY_INDEX]
+
+    documents = list(collection.find({"eval": EVAL_3_RESULTS, "scene_num" : {"$exists" : True}, "scene_part_num": {"$exists": True}, "url_string": {"$exists": False}}).batch_size(1000))
+    print("Found " + str(len(documents)) + " results")
+
+    for doc in documents:
+        hypercube_num = doc["scene_part_num"]
+        scene = doc["scene_num"]
+        url_string = "eval=" + doc["eval"] + "&category_type=" + doc["category_type"] + "&test_num=" + str(hypercube_num) + "&scene=" + str(scene)
+        
+        result = collection.update_one({"_id": ObjectId(doc["_id"])}, [{"$set": {'scene_num': scene, 'test_num': hypercube_num, "url_string": url_string}}, {"$unset": ['scene_part_num']}], True)
+
+def update_scene_num_refs_history_eval_2():
+    print("Begin Processing " + EVAL_2_RESULTS)
+    collection = mongoDB[HISTORY_INDEX]
+
+    documents = list(collection.find({"eval": EVAL_2_RESULTS, "scene_num" : {"$exists" : True}, "scene_part_num": {"$exists": True}}).batch_size(1000))
+    print("Found " + str(len(documents)) + " results")
+
+    for doc in documents:
+
+        test_num = int(doc["scene_num"])
+        scene = int(doc["scene_part_num"])
+        url_string = "eval=" + doc["eval"] + "&test_type=" + doc["test_type"] + "&test_num=" + str(test_num) + "&scene=" + str(scene)
+    
+        result = collection.update_one({"_id": ObjectId(doc["_id"])}, [{"$set": {'scene_num': scene, 'test_num': test_num, 'url_string': url_string}}, {"$unset": ['scene_part_num']}], True)
+
+def update_scene_num_refs_scenes_eval_2():
+    print("Begin Processing " + EVAL_2_SCENES)
+    collection = mongoDB[SCENE_INDEX]
+
+    documents = list(collection.find({"eval": EVAL_2_SCENES, "scene_num" : {"$exists" : True}, "scene_part_num": {"$exists": True}}).batch_size(1000))
+    print("Found " + str(len(documents)) + " results")
+
+    for doc in documents:
+        
+        test_num = int(doc["scene_num"])
+        scene = int(doc["scene_part_num"])
+
+        result = collection.update_one({"_id": ObjectId(doc["_id"])}, [{"$set": {'scene_num': scene, 'test_num': test_num}}, {"$unset": ['scene_part_num']}], True)
+
+def update_scene_num_refs_scenes_eval_3():
+    print("Begin Processing " + EVAL_3_SCENES)
+    collection = mongoDB[SCENE_INDEX]
+
+    documents = list(collection.find({"eval": EVAL_3_SCENES, "sequenceNumber" : {"$exists" : True}, "sceneNumber": {"$exists": True}, "goal.sceneInfo.sequenceId": {"$exists": True}}).batch_size(1000))
+    print("Found " + str(len(documents)) + " results")
+
+    for doc in documents:
+        test_num = doc["sequenceNumber"]
+        scene = doc["sceneNumber"]
+        hypercubeId = doc["goal"]["sceneInfo"]["sequenceId"]
+    
+        result = collection.update_one({"_id": ObjectId(doc["_id"])}, [{"$set": {'scene_num': scene, 'test_num': test_num, "goal.sceneInfo.hypercubeId": hypercubeId}}, {"$unset": ['sequenceNumber', 'sceneNumber', 'goal.sceneInfo.sequenceId']}], True)
+
+def update_collection_keys():
+    print("Begin Processing collection_keys...")
+    collection = mongoDB["collection_keys"]
+
+    documents = list(collection.find({}))
+    print("Found " + str(len(documents)) + " results")
+
+    for doc in documents:
+        if('scene_part_num' in doc['keys'] and "Results" in doc['name']):
+            result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$push": {'keys': "test_num"}}, True)
+            result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$pull": {'keys': "scene_part_num"}}, True)
+        else:
+            keys_to_add = []
+            keys_to_remove = []
+
+            # add/remove for all eval scenes keys
+            if "test_num" not in doc['keys']:
+                keys_to_add.append("test_num")
+            if "scene_part_num" in doc['keys']:
+                keys_to_remove.append("scene_part_num")
+
+
+            # add/remove for eval 3+ scenes keys only
+            if "3" in doc['name']:
+                # add
+                if "goal.sceneInfo.hypercubeId" not in doc['keys']:
+                    keys_to_add.append("goal.sceneInfo.hypercubeId")
+                
+                # remove
+                if "goal.sceneInfo.sequenceId" in doc['keys']:
+                    keys_to_remove.append("goal.sceneInfo.sequenceId")
+                if "sequenceNumber" in doc['keys']:
+                    keys_to_remove.append("sequenceNumber")
+                if "sceneNumber" in doc['keys']:
+                    keys_to_remove.append("sceneNumber")
+
+            result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$push": {'keys': { "$each": keys_to_add}}}, True)
+            result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$pull": {'keys': { "$in": keys_to_remove}}}, True)
+
+def update_mcs_history_keys():
+    print("Begin Processing mcs_history_keys...")
+    collection = mongoDB["mcs_history_keys"]
+
+    documents = list(collection.find({}))
+    print("Found " + str(len(documents)) + " results")
+
+    for doc in documents:
+        if "scene_part_num" in doc:
+            result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$push": {'keys': "test_num"}}, True)
+            result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$pull": {'keys': "scene_part_num"}}, True)
+
+def update_mcs_scenes_keys():
+    print("Begin Processing mcs_scenes_keys...")
+    collection = mongoDB["mcs_scenes_keys"]
+    keys_to_remove = []
+    keys_to_add = []
+
+    documents = list(collection.find({}))
+    print("Found " + str(len(documents)) + " results")
+
+    for doc in documents:
+
+        # check keys to add
+        if "test_num" not in doc:
+            keys_to_add.append("test_num")
+        if "goal.sceneInfo.hypercubeId" not in doc:
+            keys_to_add.append("goal.sceneInfo.hypercubeId")
+
+        # check keys to remove
+        if "scene_part_num" in doc:
+            keys_to_remove.append("scene_part_num")
+        if "goal.sceneInfo.sequenceId" in doc:
+            keys_to_remove.append("goal.sceneInfo.sequenceId")
+        if "sequenceNumber" in doc:
+            keys_to_remove.append("sequenceNumber")
+        if "sceneNumber" in doc:
+            keys_to_remove.append("sceneNumber")
+
+        result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$push": {'keys': { "$each": keys_to_add}}}, True)
+        result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$pull": {'keys': { "$in": keys_to_remove}}}, True)
+   
+def delete_old_saved_query():
+    print("Deleting single saved query...")
+    collection = mongoDB["savedQueries"]
+
+    results = collection.delete_one({"_id": ObjectId("60008951c9ef6d5e7a77eb65")})
+
+# one time run script (MCS-520)
+def main():
+    update_scene_num_refs_history_eval_2()
+    update_scene_num_refs_history_eval_3()
+    update_scene_num_refs_scenes_eval_2()
+    update_scene_num_refs_scenes_eval_3()
+
+    update_collection_keys()
+    update_mcs_history_keys()
+    update_mcs_scenes_keys()
+    delete_old_saved_query()
+
+if __name__ == "__main__":
+    main()

--- a/update_scene_num_refs.py
+++ b/update_scene_num_refs.py
@@ -29,29 +29,6 @@ def update_scene_num_refs_history_eval_3():
     result = collection.update_many({"eval": EVAL_3_RESULTS, "scene_part_num": {"$exists": True}}, {"$rename": {'scene_part_num' : 'test_num'}}, False)
     print("update_many performed on " + str(result.matched_count) + " documents")
 
-    categories = [
-        "agents efficient action path lure",
-        "agents efficient action time control",
-        "agents object preference",
-        "object permanence",
-        "retrieval_container",
-        "retrieval_obstacle",
-        "retrieval_occluder",
-        "shape constancy",
-        "spatio temporal continuity"
-    ]
-    
-    # update url_string one by one
-    for cat in categories:
-        documents = list(collection.find({"eval": EVAL_3_RESULTS, "category_type": cat, "url_string": {"$exists": False}}).batch_size(1000))
-        print("Found " + str(len(documents)) + " results for category_type " + cat)
-
-        for doc in documents:
-            url_string = "eval=" + doc["eval"] + "&category_type=" + doc["category_type"] + "&test_num=" + str(doc["test_num"]) + "&scene=" + str(doc["scene_num"])
-            
-            result = collection.update_one({"_id": ObjectId(doc["_id"])}, {"$set": { "url_string": url_string}}, True)
-
-
 def update_scene_num_refs_history_eval_2():
     print("Begin Processing " + EVAL_2_RESULTS)
     collection = mongoDB[HISTORY_INDEX]
@@ -63,9 +40,8 @@ def update_scene_num_refs_history_eval_2():
 
         test_num = int(doc["scene_num"])
         scene = int(doc["scene_part_num"])
-        url_string = "eval=" + doc["eval"] + "&test_type=" + doc["test_type"] + "&test_num=" + str(test_num) + "&scene=" + str(scene)
     
-        result = collection.update_one({"_id": ObjectId(doc["_id"])}, [{"$set": {'scene_num': scene, 'test_num': test_num, 'url_string': url_string}}, {"$unset": ['scene_part_num']}], True)
+        result = collection.update_one({"_id": ObjectId(doc["_id"])}, [{"$set": {'scene_num': scene, 'test_num': test_num}}, {"$unset": ['scene_part_num', 'url_string']}], True)
 
 def update_scene_num_refs_scenes_eval_2():
     print("Begin Processing " + EVAL_2_SCENES)


### PR DESCRIPTION
Mainly, renamed and consolidated fields like sequenceNumber/scene_part_num/scene_num for clarity. Now it should be test_num and scene_num across all the data, and is stored as an integer regardless of eval (types were different before). Removed any duplicate fields like sequenceNumber, sceneNumber, etc. 

Also renamed sequenceId to hypercubeId to be consistent with newer scene files, and added the analysis UI url to the data in mcs_history as "url_string". 

To update existing data locally + on EC2, update_scene_num_refs.py needs to be run once. 

To view in the UI, see: https://github.com/NextCenturyCorporation/mcs-ui/pull/22