### PR TITLE
Adding collection keys for eval 3.5

### DIFF
--- a/create_keys_script.py
+++ b/create_keys_script.py
@@ -51,8 +51,10 @@ def main():
     print("Starting Key Processing")
     find_collection_keys(HISTORY_INDEX, "Evaluation 2 Results")
     find_collection_keys(HISTORY_INDEX, "Evaluation 3 Results")
+    find_collection_keys(HISTORY_INDEX, "Evaluation 3.5 Results")
     find_collection_keys(SCENE_INDEX, "Evaluation 2 Scenes")
     find_collection_keys(SCENE_INDEX, "Evaluation 3 Scenes")
+    find_collection_keys(SCENE_INDEX, "Evaluation 3.5 Scenes")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Noticed the query results page wasn't working for Eval 3.5 dropdowns. I think this is all that needs to be added + running the updated script again?  

We probably want to not have these values hardcoded in the future and query the database instead for values. And then maybe we can have an update all versus just adding new ones so it takes a little less time. 

If we want to automate it, I'm not sure exactly what the trigger would be (wondering if it should wait until everything is processed vs just doing it after a single new scene/history record with a new eval identifier appears).