### PR TITLE
[Ingest] MCS-700 Consolidation of Debug Scene File Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # mcs-ingest
-Ingest data into Elasticsearch for MCS
 
-# Setup
+Ingest data into MongoDB for MCS
+
+# Mongo Setup
+
+## Standalone
+
+See the official MongoDB installation page here: https://docs.mongodb.com/manual/installation/
+
+Change each instantiation of the MongoClient in our Python code to: `MongoClient('mongodb://localhost:27017/mcs')`
+
+## With the MCS UI
+
+See the mcs-ui README here: https://github.com/NextCenturyCorporation/mcs-ui/blob/master/README.md
+
+# Python Setup
 
 ## Using python virtual environment:
 

--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -18,9 +18,7 @@ mongoDB = client['mcs']
 #    that we want to just map the fields we want to the schema
 KEYS_TO_DELETE = [
     'image',
-    'sequenceNumber',
-    'hypercubeNumber',
-    'sceneNumber'
+    'debug'
 ]
 
 SCENE_INDEX = "mcs_scenes"
@@ -114,16 +112,16 @@ def build_scene_item(file_name: str, folder: str, eval_name: str) -> dict:
     scene = load_json_file(folder, file_name)
 
     if eval_name is None:
-        scene["eval"] = scene["evaluation"]
-        eval_name = scene["evaluation"]
+        scene["eval"] = scene["debug"]["evaluation"]
+        eval_name = scene["debug"]["evaluation"]
     else:
         scene["eval"] = eval_name
 
-    scene["scene_num"] = scene["sceneNumber"]
-    if "sequenceNumber" in scene:
-        scene["test_num"] = scene["sequenceNumber"]
+    scene["scene_num"] = scene["debug"]["sceneNumber"]
+    if "sequenceNumber" in scene["debug"]:
+        scene["test_num"] = scene["debug"]["sequenceNumber"]
     else:
-        scene["test_num"] = scene["hypercubeNumber"]
+        scene["test_num"] = scene["debug"]["hypercubeNumber"]
 
     if "sequenceId" in scene["goal"]["sceneInfo"]:
         scene["goal"]["sceneInfo"]["hypercubeId"] = scene["goal"][
@@ -143,7 +141,7 @@ def automated_scene_ingest_file(file_name: str, folder: str) -> None:
     check_exists = collection.find(
         {
             "name": scene_item["name"],
-            "evaluation": scene_item["evaluation"]
+            "evaluation": scene_item["debug"]["evaluation"]
         }
     )
 
@@ -302,7 +300,7 @@ def process_score(
             history_item["score"] = {}
             history_item["score"]["score"] = -1
             history_item["score"]["ground_truth"] = 1 if "plausible" == scene[
-                "answer"]["choice"] else 0
+                "goal"]["answer"]["choice"] else 0
 
     # Psychologists wanted to see a definitive answer of correctness
     if history_item["score"]["score"] == 1:
@@ -393,8 +391,8 @@ def build_history_item(
             history_item["scene_num"] = scene["scene_num"]
             history_item["test_num"] = scene["test_num"]
         else:
-            history_item["scene_num"] = scene["sceneNumber"]
-            history_item["test_num"] = scene["hypercubeNumber"]
+            history_item["scene_num"] = scene["debug"]["sceneNumber"]
+            history_item["test_num"] = scene["debug"]["hypercubeNumber"]
 
         history_item["scene_goal_id"] = scene["goal"]["sceneInfo"]["id"][0]
         history_item["test_type"] = scene["goal"]["sceneInfo"]["secondaryType"]

--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -297,10 +297,11 @@ def process_score(
                 "goal"]["answer"]["choice"] or "expected" == scene[
                     "goal"]["answer"]["choice"]) else 0
         else:
+            # Eval 2 backwards compatiblity
             history_item["score"] = {}
             history_item["score"]["score"] = -1
             history_item["score"]["ground_truth"] = 1 if "plausible" == scene[
-                "goal"]["answer"]["choice"] else 0
+                "answer"]["choice"] else 0
 
     # Psychologists wanted to see a definitive answer of correctness
     if history_item["score"]["score"] == 1:

--- a/tests/test_juliett_0001_01_debug.json
+++ b/tests/test_juliett_0001_01_debug.json
@@ -4,12 +4,6 @@
   "ceilingMaterial": "AI2-THOR/Materials/Ceramics/GREYGRANITE",
   "floorMaterial": "AI2-THOR/Materials/Wood/LightWoodCounters 1",
   "wallMaterial": "AI2-THOR/Materials/Walls/YellowDrywall",
-  "floorColors": [
-    "brown"
-  ],
-  "wallColors": [
-    "yellow"
-  ],
   "performerStart": {
     "position": {
       "x": 0,
@@ -24,34 +18,43 @@
     {
       "id": "e5f4d8ac-a80a-420d-b888-c3c18d47ddc5",
       "type": "letter_l_narrow",
-      "role": "target",
-      "info": ["medium","heavy","green","wood","letter l","medium heavy","medium wood","medium green","medium letter l","heavy wood","heavy green","heavy letter l","wood green","wood letter l","green letter l","medium heavy green wood letter l","target"],
       "mass": 4.5,
-      "positionY": 0.45,
       "salientMaterials": ["wood"],
-      "color": [
-        "green"
-      ],
-      "shape": [
-        "letter l"
-      ],
-      "size": "medium",
-      "dimensions": {
-        "x": 0.45,
-        "y": 0.9,
-        "z": 0.45
+      "debug": {
+          "role": "target",
+          "info": ["medium","heavy","green","wood","letter l","medium heavy","medium wood","medium green","medium letter l","heavy wood","heavy green","heavy letter l","wood green","wood letter l","green letter l","medium heavy green wood letter l","target"],
+          "positionY": 0.45,
+          "color": [
+            "green"
+          ],
+          "shape": [
+            "letter l"
+          ],
+          "size": "medium",
+          "dimensions": {
+            "x": 0.45,
+            "y": 0.9,
+            "z": 0.45
+          },
+          "untrainedCategory": false,
+          "untrainedColor": false,
+          "untrainedCombination": false,
+          "untrainedShape": false,
+          "untrainedSize": false,
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "materialCategory": [
+            "intuitive_physics_wood"
+          ],
+          "weight": "heavy",
+          "goalString": "medium heavy green wood letter l",
+          "enclosedAreas": [],
+          "isTarget": true
       },
-      "untrainedCategory": false,
-      "untrainedColor": false,
-      "untrainedCombination": false,
-      "untrainedShape": false,
-      "untrainedSize": false,
       "moveable": true,
-      "offset": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
       "shows": [
         {
           "position": {
@@ -94,13 +97,7 @@
           ]
         }
       ],
-      "materialCategory": [
-        "intuitive_physics_wood"
-      ],
       "materials": ["UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 3"],
-      "weight": "heavy",
-      "goalString": "medium heavy green wood letter l",
-      "enclosedAreas": [],
       "moves": [
         {
           "stepBegin": 2,
@@ -117,30 +114,31 @@
         {
           "stepBegin": 29
         }
-      ],
-      "isTarget": true
+      ]
     },
     {
       "id": "pole_b51f7908-9dc8-42a1-a6a9-c59bc41e35b9",
-      "role": "structural",
-      "color": [
-        "magenta",
-        "cyan"
-      ],
-      "info": [],
-      "shape": [
-        "pole"
-      ],
-      "size": "medium",
       "type": "cylinder",
       "kinematic": true,
       "structure": true,
       "mass": 50,
       "materials": ["Custom/Materials/Magenta"],
-      "dimensions": {
-        "x": 0.2,
-        "y": 10,
-        "z": 0.2
+      "debug": {
+          "role": "structural",
+          "color": [
+            "magenta",
+            "cyan"
+          ],
+          "info": [],
+          "shape": [
+            "pole"
+          ],
+          "size": "medium",
+          "dimensions": {
+            "x": 0.2,
+            "y": 10,
+            "z": 0.2
+          }
       },
       "shows": [
         {
@@ -190,34 +188,52 @@
     {
       "id": "a6a54a01-a148-49d4-91ab-508017c8b9b8",
       "type": "cube",
-      "role": "structural",
-      "info": ["medium","massive","red","rectangular prism","medium massive","medium red","medium rectangular prism","massive red","massive rectangular prism","red rectangular prism","medium massive red rectangular prism","structural"],
       "mass": 115,
-      "positionY": 0.7,
       "salientMaterials": [],
-      "color": [
-        "red"
-      ],
-      "shape": [
-        "rectangular prism"
-      ],
-      "size": "medium",
-      "dimensions": {
-        "x": 0.9,
-        "y": 1.4,
-        "z": 1.0
-      },
-      "untrainedCategory": false,
-      "untrainedColor": false,
-      "untrainedCombination": false,
-      "untrainedShape": false,
-      "untrainedSize": false,
       "kinematic": true,
       "structure": true,
-      "offset": {
-        "x": 0,
-        "y": 0,
-        "z": 0
+      "debug": {
+          "role": "structural",
+          "info": ["medium","massive","red","rectangular prism","medium massive","medium red","medium rectangular prism","massive red","massive rectangular prism","red rectangular prism","medium massive red rectangular prism","structural"],
+          "positionY": 0.7,
+          "color": [
+            "red"
+          ],
+          "shape": [
+            "rectangular prism"
+          ],
+          "size": "medium",
+          "dimensions": {
+            "x": 0.9,
+            "y": 1.4,
+            "z": 1.0
+          },
+          "untrainedCategory": false,
+          "untrainedColor": false,
+          "untrainedCombination": false,
+          "untrainedShape": false,
+          "untrainedSize": false,
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "materialCategory": [],
+          "weight": "massive",
+          "goalString": "medium massive red rectangular prism",
+          "enclosedAreas": [],
+          "isAgent": false,
+          "isConfusor": false,
+          "isContainer": false,
+          "isContext": false,
+          "isHome": false,
+          "isIntuitivePhysicsOccluder": false,
+          "isNonTarget": false,
+          "isObstacle": false,
+          "isOccluder": false,
+          "isStructural": true,
+          "isTarget": false,
+          "isWall": false
       },
       "shows": [
         {
@@ -239,55 +255,57 @@
           }
         }
       ],
-      "materialCategory": [],
-      "materials": ["AI2-THOR/Materials/Ceramics/RedBrick"],
-      "weight": "massive",
-      "goalString": "medium massive red rectangular prism",
-      "enclosedAreas": [],
-      "isAgent": false,
-      "isConfusor": false,
-      "isContainer": false,
-      "isContext": false,
-      "isHome": false,
-      "isIntuitivePhysicsOccluder": false,
-      "isNonTarget": false,
-      "isObstacle": false,
-      "isOccluder": false,
-      "isStructural": true,
-      "isTarget": false,
-      "isWall": false
+      "materials": ["AI2-THOR/Materials/Ceramics/RedBrick"]
     },
     {
       "id": "invisible_support",
       "type": "cube",
-      "role": "structural",
-      "info": ["medium","massive","red","rectangular prism","medium massive","medium red","medium rectangular prism","massive red","massive rectangular prism","red rectangular prism","medium massive red rectangular prism","structural"],
       "mass": 115,
-      "positionY": 0.7,
       "salientMaterials": [],
-      "color": [
-        "red"
-      ],
-      "shape": [
-        "rectangular prism"
-      ],
-      "size": "medium",
-      "dimensions": {
-        "x": 0.9,
-        "y": 1.0,
-        "z": 1.0
-      },
-      "untrainedCategory": false,
-      "untrainedColor": false,
-      "untrainedCombination": false,
-      "untrainedShape": false,
-      "untrainedSize": false,
       "kinematic": true,
       "structure": true,
-      "offset": {
-        "x": 0,
-        "y": 0,
-        "z": 0
+      "debug": {
+          "role": "structural",
+          "info": ["medium","massive","red","rectangular prism","medium massive","medium red","medium rectangular prism","massive red","massive rectangular prism","red rectangular prism","medium massive red rectangular prism","structural"],
+          "positionY": 0.7,
+          "color": [
+            "red"
+          ],
+          "shape": [
+            "rectangular prism"
+          ],
+          "size": "medium",
+          "dimensions": {
+            "x": 0.9,
+            "y": 1.0,
+            "z": 1.0
+          },
+          "untrainedCategory": false,
+          "untrainedColor": false,
+          "untrainedCombination": false,
+          "untrainedShape": false,
+          "untrainedSize": false,
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "materialCategory": [],
+          "weight": "massive",
+          "goalString": "medium massive red rectangular prism",
+          "enclosedAreas": [],
+          "isAgent": false,
+          "isConfusor": false,
+          "isContainer": false,
+          "isContext": false,
+          "isHome": false,
+          "isIntuitivePhysicsOccluder": false,
+          "isNonTarget": false,
+          "isObstacle": false,
+          "isOccluder": false,
+          "isStructural": true,
+          "isTarget": false,
+          "isWall": false
       },
       "shows": [
         {
@@ -309,23 +327,7 @@
           }
         }
       ],
-      "materialCategory": [],
       "materials": ["AI2-THOR/Materials/Ceramics/RedBrick"],
-      "weight": "massive",
-      "goalString": "medium massive red rectangular prism",
-      "enclosedAreas": [],
-      "isAgent": false,
-      "isConfusor": false,
-      "isContainer": false,
-      "isContext": false,
-      "isHome": false,
-      "isIntuitivePhysicsOccluder": false,
-      "isNonTarget": false,
-      "isObstacle": false,
-      "isOccluder": false,
-      "isStructural": true,
-      "isTarget": false,
-      "isWall": false,
       "shrouds": [
         {
           "stepBegin": 0,
@@ -729,10 +731,18 @@
       ]
     }
   },
-  "evaluationOnly": true,
   "intuitivePhysics": true,
-  "hypercubeNumber": 1,
-  "sceneNumber": 1,
-  "evaluation": "Evaluation 3.5 Scenes",
-  "training": false
+  "debug": {
+      "floorColors": [
+        "brown"
+      ],
+      "wallColors": [
+        "yellow"
+      ],
+      "evaluationOnly": true,
+      "hypercubeNumber": 1,
+      "sceneNumber": 1,
+      "evaluation": "Evaluation 3.5 Scenes",
+      "training": false
+  }
 }

--- a/tests/test_mcs_scene_ingest.py
+++ b/tests/test_mcs_scene_ingest.py
@@ -11,16 +11,18 @@ class TestMcsSceneIngest(unittest.TestCase):
         scene_file = mcs_scene_ingest.load_json_file(
             "tests", TEST_SCENE_FILE_NAME)
         self.assertEqual(scene_file["name"], "juliett_0001_01")
-        self.assertEqual(scene_file["training"], False)
+        self.assertEqual(scene_file["debug"]["training"], False)
 
     def test_delete_keys_from_scene(self):
         test_scene = {
             "name": "test",
             "version": 2,
             "image": "image_to_delete",
-            "sequenceNumber": 1,
-            "hypercubeNumber": 5,
-            "sceneNumber": 100
+            "debug": {
+                "sequenceNumber": 1,
+                "hypercubeNumber": 5,
+                "sceneNumber": 100
+            }
         }
 
         scene_removed_keys = mcs_scene_ingest.delete_keys_from_scene(
@@ -28,9 +30,7 @@ class TestMcsSceneIngest(unittest.TestCase):
         self.assertEqual(scene_removed_keys["name"], "test")
         self.assertEqual(scene_removed_keys["version"], 2)
         self.assertEqual(scene_removed_keys.get("image"), None)
-        self.assertEqual(scene_removed_keys.get("sequenceNumber"), None)
-        self.assertEqual(scene_removed_keys.get("hypercubeNumber"), None)
-        self.assertEqual(scene_removed_keys.get("sceneNumber"), None)
+        self.assertEqual(scene_removed_keys.get("debug"), None)
 
     def test_find_scene_files(self):
         scene_files = mcs_scene_ingest.find_scene_files("tests")
@@ -46,8 +46,7 @@ class TestMcsSceneIngest(unittest.TestCase):
             TEST_SCENE_FILE_NAME, "tests", None)
         self.assertEqual(scene["eval"], "Evaluation 3.5 Scenes")
         self.assertEqual(scene["test_num"], 1)
-        self.assertEqual(scene.get("sequenceNumber"), None)
-        self.assertEqual(scene.get("hypercubeNumber"), None)
+        self.assertEqual(scene.get("debug"), None)
 
     def test_determine_evaluation_hist_name(self):
         eval_name = mcs_scene_ingest.determine_evaluation_hist_name(


### PR DESCRIPTION
- Updated the scene ingest code to read from the new debug scene file properties.
- Added some mongo setup instructions to the README.

You can generate example scenes on your own, but here's a set that I used for my testing: https://ta2-examples.s3.amazonaws.com/mcs700_scenes.zip

Corresponding Scene Generator PR: https://github.com/NextCenturyCorporation/mcs-private/pull/32
Corresponding Python PR: https://github.com/NextCenturyCorporation/MCS/pull/357