### PR TITLE
MCS-973: Add error handling for automated ingest

### DIFF
--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -379,7 +379,7 @@ def calculate_reorientation_true_score(
         interactive_goal_achieved: int) -> int:
     # This is correct if the agent goes to the correct corner first
     if(len(corner_visit_order) > 0):
-        return 1 if corner_visit_order[0].type == "correct" else 0
+        return 1 if corner_visit_order[0]["type"] == "correct" else 0
     else:
         return interactive_goal_achieved
 


### PR DESCRIPTION
This code pushes files that ingest fails on to another queue with the name and the error, potential future work could be to consume this messages at an interval and using SNS send an email with all the errors potentially, future future work, we would have to whiteboard it.

Also fixed a bug with corner ingest.