### PR TITLE
MCS-982:  Fix intuitive physics scoring

### DIFF
--- a/mcs_scene_ingest.py
+++ b/mcs_scene_ingest.py
@@ -497,8 +497,8 @@ def process_score(
                 ("plausible" == scene["goal"]["answer"]["choice"] or
                  "expected" == scene["goal"]["answer"]["choice"]) else 0
             history_item["score"]["score"] = 1 if \
-                history_item["score"]["classification"] == \
-                history_item["score"]["ground_truth"] else 0
+                float(history_item["score"]["classification"]) == \
+                float(history_item["score"]["ground_truth"]) else 0
         else:
             # Eval 2 backwards compatiblity
             history_item["score"] = {}

--- a/tests/occluders_0001_17_baseline.json
+++ b/tests/occluders_0001_17_baseline.json
@@ -20097,7 +20097,7 @@
     }
   ],
   "score": {
-    "classification": "",
+    "classification": "0",
     "confidence": "1"
   }
 }

--- a/tests/test_eval_3-5_level2_baseline_juliett_0001_01.json
+++ b/tests/test_eval_3-5_level2_baseline_juliett_0001_01.json
@@ -14830,7 +14830,7 @@
     }
   ],
   "score": {
-    "classification": "plausible",
+    "classification": "1",
     "confidence": "1"
   }
 }

--- a/tests/test_mcs_scene_ingest.py
+++ b/tests/test_mcs_scene_ingest.py
@@ -219,6 +219,32 @@ class TestMcsSceneIngest(unittest.TestCase):
         self.assertEqual(history_item_2['score']['weighted_score_worth'], 0)
         self.assertEqual(history_item_2['score']['score_description'], 'Correct')
 
+    def test_process_score_correct(self):
+        history_item = {
+            'category': 'passive',
+            'test_type': 'intuitive physics',
+            'score': {'classification': '1'}
+        }
+        scene = {'goal': {'answer': {'choice': 'plausible'}}}
+        history_item["score"] = mcs_scene_ingest.process_score(
+            history_item, scene, False, False, None, False, None, None)
+
+        self.assertEqual(history_item['score']['score'], 1)
+        self.assertEqual(history_item['score']['score_description'], 'Correct')
+
+    def test_process_score_incorrect(self):
+        history_item = {
+            'category': 'passive',
+            'test_type': 'intuitive physics',
+            'score': {'classification': '0'}
+        }
+        scene = {'goal': {'answer': {'choice': 'plausible'}}}
+        history_item["score"] = mcs_scene_ingest.process_score(
+            history_item, scene, False, False, None, False, None, None)
+
+        self.assertEqual(history_item['score']['score'], 0)
+        self.assertEqual(history_item['score']['score_description'], 'Incorrect')
+
 
 if __name__ == '__main__':
     logging.basicConfig(


### PR DESCRIPTION
Scoring was comparing a string to int, cleaning this up in ingest for now, will evaluate how to return correct values throughout system after Eval.