### PR TITLE
MCS-999: Move MediaConvert Lambda function into ingest code, using queue system

### DIFF
--- a/mcs_automated_media_convert.py
+++ b/mcs_automated_media_convert.py
@@ -1,0 +1,93 @@
+import boto3
+import datetime
+import glob
+import json
+import logging
+import os
+import random
+import traceback
+import urllib3
+import uuid
+
+# Get SQS Queues
+sqs = boto3.resource('sqs')
+media_queue = sqs.get_queue_by_name(QueueName='media-convert-queue')
+dev_media_queue = sqs.get_queue_by_name(QueueName='dev-media-convert-queue')
+media_error_queue = sqs.get_queue_by_name(QueueName='error-media-convert-queue')
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+prod_media_endpoint = "https://vasjpylpa.mediaconvert.us-east-1.amazonaws.com"
+dev_media_endpoint = "https://mqm13wgra.mediaconvert.us-east-2.amazonaws.com"
+
+def process_message(message, message_type):
+    message_body = json.loads(message.body)
+    for record in message_body["Records"]:
+        # Create Variables Needed for Media Convert
+        assetID = str(uuid.uuid4())
+        sourceS3Bucket = record['s3']['bucket']['name']
+        sourceS3Key = record['s3']['object']['key']
+        sourceS3 = 's3://'+ sourceS3Bucket + '/' + sourceS3Key
+        sourceS3Basename = os.path.splitext(os.path.basename(sourceS3))[0]
+        sourceS3Foldername = os.path.dirname(sourceS3Key)
+
+        # Get The Evaluation number to place the converted file in
+        folder_parts = sourceS3Foldername.split("-")
+        destinationFoldername = "eval-resources-" + folder_parts[len(folder_parts)-1]
+        
+        destinationS3 = 's3://' + sourceS3Bucket + '/' + destinationFoldername + "/"
+        destinationS3basename = os.path.splitext(os.path.basename(destinationS3))[0]
+        mediaConvertRole = 'arn:aws:iam::795237661910:role/MediaConvertRole'
+
+        region = 'us-east-1' if message_type == 'prod' else 'us-east-2'
+        media_url = prod_media_endpoint if message_type == 'prod' else dev_media_endpoint
+        body = {}
+        
+        # Use MediaConvert SDK UserMetadata to tag jobs with the assetID
+        # Events from MediaConvert will have the assetID in UserMedata
+        jobMetadata = {'assetID': assetID}
+
+        try:
+            with open('media_convert/job.json') as json_data:
+                jobSettings = json.load(json_data)
+
+            # Update the job settings with the source video from the S3 event and destination
+            # paths for converted videos
+            jobSettings['Inputs'][0]['FileInput'] = sourceS3
+            jobSettings['OutputGroups'][0]['OutputGroupSettings'][
+                'FileGroupSettings']['Destination'] = destinationS3 + sourceS3Basename
+            
+            # add the account-specific endpoint to the client session
+            client = boto3.client('mediaconvert', region_name=region, endpoint_url=media_url, verify=False)
+
+            # Convert the video using AWS Elemental MediaConvert
+            job = client.create_job(Role=mediaConvertRole, UserMetadata=jobMetadata, Settings=jobSettings)
+            
+            logging.info(f"Sending {sourceS3} to MediaConvert.")
+        except Exception as e:
+            response = media_error_queue.send_message(MessageBody='MediaConvertError', MessageAttributes={
+                'file': {'StringValue': str(sourceS3), 'DataType': 'String'},
+                'error': {'StringValue': str(traceback.format_exc()), 'DataType': 'String'}
+            })
+            logging.info(f"Sending {response}")
+
+
+def main():
+    while True:
+        # Check for messages on media queue
+        media_messages = media_queue.receive_messages()
+        for message in media_messages:
+            process_message(message, "prod")
+            message.delete()
+
+        # Check for messages on dev media queue
+        dev_media_messages = dev_media_queue.receive_messages()
+        for message in dev_media_messages:
+            process_message(message, "dev")
+            message.delete()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    main()

--- a/media_convert/job.json
+++ b/media_convert/job.json
@@ -1,0 +1,115 @@
+{
+    "OutputGroups": [
+      {
+        "CustomName": "MP4",
+        "Name": "File Group",
+        "Outputs": [
+          {
+            "ContainerSettings": {
+              "Container": "MP4",
+              "Mp4Settings": {
+                "CslgAtom": "INCLUDE",
+                "FreeSpaceBox": "EXCLUDE",
+                "MoovPlacement": "PROGRESSIVE_DOWNLOAD"
+              }
+            },
+            "VideoDescription": {
+              "ScalingBehavior": "DEFAULT",
+              "TimecodeInsertion": "DISABLED",
+              "AntiAlias": "ENABLED",
+              "Sharpness": 50,
+              "CodecSettings": {
+                "Codec": "H_264",
+                "H264Settings": {
+                  "InterlaceMode": "PROGRESSIVE",
+                  "NumberReferenceFrames": 3,
+                  "Syntax": "DEFAULT",
+                  "Softness": 0,
+                  "GopClosedCadence": 1,
+                  "GopSize": 90,
+                  "Slices": 1,
+                  "GopBReference": "DISABLED",
+                  "SlowPal": "DISABLED",
+                  "SpatialAdaptiveQuantization": "ENABLED",
+                  "TemporalAdaptiveQuantization": "ENABLED",
+                  "FlickerAdaptiveQuantization": "DISABLED",
+                  "EntropyEncoding": "CABAC",
+                  "MaxBitrate": 3000000,
+                  "FramerateControl": "INITIALIZE_FROM_SOURCE",
+                  "RateControlMode": "QVBR",
+                  "QvbrSettings": {
+                    "QvbrQualityLevel": 7
+                  },                 
+                  "CodecProfile": "MAIN",
+                  "Telecine": "NONE",
+                  "MinIInterval": 0,
+                  "AdaptiveQuantization": "HIGH",
+                  "CodecLevel": "AUTO",
+                  "FieldEncoding": "PAFF",
+                  "SceneChangeDetect": "ENABLED",
+                  "QualityTuningLevel": "SINGLE_PASS",
+                  "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+                  "UnregisteredSeiTimecode": "DISABLED",
+                  "GopSizeUnits": "FRAMES",
+                  "ParControl": "INITIALIZE_FROM_SOURCE",
+                  "NumberBFramesBetweenReferenceFrames": 2,
+                  "RepeatPps": "DISABLED"
+                }
+              },
+              "AfdSignaling": "NONE",
+              "DropFrameTimecode": "ENABLED",
+              "RespondToAfd": "NONE",
+              "ColorMetadata": "INSERT"
+            },
+            "AudioDescriptions": [
+              {
+                "AudioTypeControl": "FOLLOW_INPUT",
+                "CodecSettings": {
+                  "Codec": "AAC",
+                  "AacSettings": {
+                    "AudioDescriptionBroadcasterMix": "NORMAL",
+                    "Bitrate": 96000,
+                    "RateControlMode": "CBR",
+                    "CodecProfile": "LC",
+                    "CodingMode": "CODING_MODE_2_0",
+                    "RawFormat": "NONE",
+                    "SampleRate": 48000,
+                    "Specification": "MPEG4"
+                  }
+                },
+                "LanguageCodeControl": "FOLLOW_INPUT"
+              }
+            ]
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "FILE_GROUP_SETTINGS",
+          "FileGroupSettings": {
+            "Destination": ""
+          }
+        }
+      }
+    ],
+    "AdAvailOffset": 0,
+    "Inputs": [
+      {
+        "AudioSelectors": {
+          "Audio Selector 1": {
+            "Offset": 0,
+            "DefaultSelection": "DEFAULT",
+            "ProgramSelection": 1
+          }
+        },
+        "VideoSelector": {
+          "ColorSpace": "FOLLOW"
+        },
+        "FilterEnable": "AUTO",
+        "PsiControl": "USE_PSI",
+        "FilterStrength": 0,
+        "DeblockFilter": "DISABLED",
+        "DenoiseFilter": "DISABLED",
+        "TimecodeSource": "EMBEDDED",
+        "FileInput": ""
+      }
+    ]
+  }


### PR DESCRIPTION
The Lambda function didn't seem to be able to generate messages to the media convert fast enough to keep up with the load of messages triggered by the amount of movies being loaded to the bucket.  Trying changing timeouts and concurrency and that didn't seem to be able to do anything.  Changed the Lambda function to write to a new queue just like we do with the history files.  Moved the code of the lambda function into ingest, where we will run it and have it listen to the media convert queues, this ensures we will not miss messages anymore.  Tested by copying all 30k+ baseline images into raw-eval-4 in about 10 minutes and the queue did not miss a single upload and the mediaconvert was able to churn on them and process them.  I don't think we will need to handle 30k+ media files that quick with the pipeline but at least we know we can handle it and it will be resilient going forward. 

Also implemented an error queue like we have with the history files so we can track any media files that fail to convert.