### PR TITLE
MCS-1355 - Fix ValueError for weighted_confidence

### DIFF
--- a/mcs_history_ingest.py
+++ b/mcs_history_ingest.py
@@ -6,7 +6,7 @@ import math
 import os
 import re
 
-from typing import List
+from typing import List, Union
 
 from pymongo import MongoClient
 import create_collection_keys
@@ -486,22 +486,27 @@ def build_new_step_obj(
         corner_visit_order)
 
 
+def calculate_weighted_confidence(history_item: dict, multiplier: int) -> Union[float,None]:
+    confidence = history_item["score"].get("confidence")
+    if confidence == "None" or confidence is None:
+        return None
+    else:
+        return float(confidence) * multiplier
+
+
 def add_weighted_cube_scoring(history_item: dict, scene: dict) -> tuple:
     if "goal" in scene and "sceneInfo" in scene["goal"]:
         if scene["goal"]["sceneInfo"]["tertiaryType"] == "shape constancy":
             if history_item["scene_goal_id"] in \
                     SHAPE_CONSTANCY_DUPLICATE_CUBE:
-                return (history_item["score"]["score"] * 2, 2, float(
-                    history_item["score"]["confidence"]) * 2)
+                return (history_item["score"]["score"] * 2, 2, calculate_weighted_confidence(history_item, 2))
             elif history_item["scene_goal_id"] in SHAPE_CONSTANCY_8X_CUBE:
-                return (history_item["score"]["score"] * 8, 8, float(
-                    history_item["score"]["confidence"]) * 8)
+                return (history_item["score"]["score"] * 8, 8, calculate_weighted_confidence(history_item, 8))
         elif scene["goal"]["sceneInfo"]["tertiaryType"] == "spatial elimination":
             if history_item["scene_goal_id"] in \
                     SPATIAL_ELIMINATION_IGNORED:
                 return (0,0,0)
-        return (history_item["score"]["score"], 1, float(
-            history_item["score"]["confidence"]))
+        return (history_item["score"]["score"], 1, calculate_weighted_confidence(history_item, 1))
     return (0,0,0)
 
   

--- a/tests/test_mcs_history_ingest.py
+++ b/tests/test_mcs_history_ingest.py
@@ -347,16 +347,14 @@ class TestMcsHistoryIngest(unittest.TestCase):
             "goal": {
                 "sceneInfo": {
                     "tertiaryType": "spatial elimination"
-                },
-                'answer': {
-                    'choice': 'plausible'
                 }
             }
         }
 
         history_item = {
-            'category': 'passive',
-            'test_type': 'spatial elimination',
+            'category': 'interactive',
+            'test_type': 'retrieval',
+            'category_type': 'spatial elimination',
             'scene_goal_id': 'A3',
             'score': {
                 'classification': '1',
@@ -375,8 +373,9 @@ class TestMcsHistoryIngest(unittest.TestCase):
         self.assertEqual(history_item['score']['weighted_confidence'], 0)
 
         history_item = {
-            'category': 'passive',
-            'test_type': 'spatial elimination',
+            'category': 'interactive',
+            'test_type': 'retrieval',
+            'category_type': 'spatial elimination',
             'scene_goal_id': 'C4',
             'score': {
                 'classification': '1',
@@ -395,8 +394,9 @@ class TestMcsHistoryIngest(unittest.TestCase):
         self.assertEqual(history_item['score']['weighted_confidence'], 0)
 
         history_item = {
-            'category': 'passive',
-            'test_type': 'spatial elimination',
+            'category': 'interactive',
+            'test_type': 'retrieval',
+            'category_type': 'spatial elimination',
             'scene_goal_id': 'C2',
             'score': {
                 'classification': '1',
@@ -413,6 +413,175 @@ class TestMcsHistoryIngest(unittest.TestCase):
         self.assertEqual(history_item['score']['weighted_score'], 1)
         self.assertEqual(history_item['score']['weighted_score_worth'], 1)
         self.assertEqual(history_item['score']['weighted_confidence'], 1)
+
+
+    def test_other_weighted_cube_scoring(self):
+        test_scene = {
+            "goal": {
+                "sceneInfo": {
+                    "tertiaryType": "shape constancy"
+                },
+                'answer': {
+                    'choice': 'plausible'
+                }
+            }
+        }
+
+        history_item = {
+            'category': 'passive',
+            'category_type': 'shape constancy',
+            'test_type': 'intuitive physics',
+            'scene_goal_id': 'A1',
+            'score': {
+                'classification': '1',
+                'score': 1,
+                'weighted_score': 1,
+                'weighted_score_worth': 1,
+                'confidence': 1,
+                'weighted_confidence': 1
+            }
+        }
+        history_item["score"] = mcs_history_ingest.process_score(
+            history_item, test_scene, True, False, None, False, None, None)
+        self.assertEqual(history_item['score']['score'], 1)
+        self.assertEqual(history_item['score']['weighted_score'], 2)
+        self.assertEqual(history_item['score']['weighted_score_worth'], 2)
+        self.assertEqual(history_item['score']['weighted_confidence'], 2)
+
+        history_item = {
+            'category': 'passive',
+            'category_type': 'shape constancy',
+            'test_type': 'intuitive physics',
+            'scene_goal_id': 'A2',
+            'score': {
+                'classification': '1',
+                'score': 1,
+                'weighted_score': 1,
+                'weighted_score_worth': 1,
+                'confidence': 1,
+                'weighted_confidence': 1
+            }
+        }
+        history_item["score"] = mcs_history_ingest.process_score(
+            history_item, test_scene, True, False, None, False, None, None)
+        self.assertEqual(history_item['score']['score'], 1)
+        self.assertEqual(history_item['score']['weighted_score'], 8)
+        self.assertEqual(history_item['score']['weighted_score_worth'], 8)
+        self.assertEqual(history_item['score']['weighted_confidence'], 8)
+
+        test_scene = {
+            "goal": {
+                "sceneInfo": {
+                    "tertiaryType": "support relations"
+                }
+            }
+        }
+
+        history_item = {
+            'category': 'interactive',
+            'test_type': 'retrieval',
+            'category_type': 'support relations',
+            'scene_goal_id': 'A1',
+            'score': {
+                'classification': '1',
+                'score': 1,
+                'weighted_score': 0,
+                'weighted_score_worth': 0,
+                'confidence': 1,
+                'weighted_confidence': 0
+            }
+        }
+        history_item["score"] = mcs_history_ingest.process_score(
+            history_item, test_scene, 1, 1, None, False, None, None)
+        self.assertEqual(history_item['score']['score'], 1)
+        self.assertEqual(history_item['score']['weighted_score'], 1)
+        self.assertEqual(history_item['score']['weighted_score_worth'], 1)
+        self.assertEqual(history_item['score']['weighted_confidence'], 1)
+
+
+    def test_weighted_cube_scoring_confidence_none(self):
+        test_scene = {
+            "goal": {
+                "sceneInfo": {
+                    "tertiaryType": "shape constancy"
+                },
+                'answer': {
+                    'choice': 'plausible'
+                }
+            }
+        }
+
+        history_item = {
+            'category': 'passive',
+            'category_type': 'shape constancy',
+            'test_type': 'intuitive physics',
+            'scene_goal_id': 'A1',
+            'score': {
+                'classification': '1',
+                'score': 1,
+                'weighted_score': 1,
+                'weighted_score_worth': 1,
+                'confidence': "None",
+                'weighted_confidence': 1
+            }
+        }
+        history_item["score"] = mcs_history_ingest.process_score(
+            history_item, test_scene, True, False, None, False, None, None)
+        self.assertEqual(history_item['score']['score'], 1)
+        self.assertEqual(history_item['score']['weighted_score'], 2)
+        self.assertEqual(history_item['score']['weighted_score_worth'], 2)
+        self.assertIsNone(history_item['score']['weighted_confidence'])
+
+        history_item = {
+            'category': 'passive',
+            'category_type': 'shape constancy',
+            'test_type': 'intuitive physics',
+            'scene_goal_id': 'A2',
+            'score': {
+                'classification': '1',
+                'score': 1,
+                'weighted_score': 1,
+                'weighted_score_worth': 1,
+                'confidence': "None",
+                'weighted_confidence': 1
+            }
+        }
+        history_item["score"] = mcs_history_ingest.process_score(
+            history_item, test_scene, True, False, None, False, None, None)
+        self.assertEqual(history_item['score']['score'], 1)
+        self.assertEqual(history_item['score']['weighted_score'], 8)
+        self.assertEqual(history_item['score']['weighted_score_worth'], 8)
+        self.assertIsNone(history_item['score']['weighted_confidence'])
+
+        test_scene = {
+            "goal": {
+                "sceneInfo": {
+                    "tertiaryType": "support relations"
+                }
+            }
+        }
+
+        history_item = {
+            'category': 'interactive',
+            'test_type': 'retrieval',
+            'category_type': 'support relations',
+            'scene_goal_id': 'A1',
+            'score': {
+                'classification': '1',
+                'score': 1,
+                'weighted_score': 0,
+                'weighted_score_worth': 0,
+                'confidence': "None",
+                'weighted_confidence': 0
+            }
+        }
+        history_item["score"] = mcs_history_ingest.process_score(
+            history_item, test_scene, 1, 1, None, False, None, None)
+        self.assertEqual(history_item['score']['score'], 1)
+        self.assertEqual(history_item['score']['weighted_score'], 1)
+        self.assertEqual(history_item['score']['weighted_score_worth'], 1)
+        self.assertIsNone(history_item['score']['weighted_confidence'])
+
 
     def test_build_new_step_obj_interactive(self):
         step = {


### PR DESCRIPTION
In the history file, we accept the None type as well as a float for confidence/score values. When the weighted_confidence is calculated, ingest attempts cast to a float(), which was failing because of trying to convert "None". In that case, we want to just return None/null for weighted_confidence. Re-ingested and checked the UI locally with this change, didn't look like anything broke + added some unit tests as well. 

Note that this was to fix weighted_confidence, the original confidence value is left as is. 