### PR TITLE
MCS-1349 scorecard updates

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,12 +1,12 @@
 from pymongo import MongoClient
-from scripts._0_5_5_add_slice_to_history import add_slice_to_history_items
+from scripts._0_5_6_update_scorecard_fields import update_scorecard_fields
 
 # We might want to move mongo user/pass to new file
 VERSION_COLLECTION = "mcs_version"
 
 # Change this version if running a new deploy script
 # Make sure the first two numbers match the current MCS API Release
-db_version = "0.5.4"
+db_version = "0.5.6"
 
 
 def check_version(mongoDB):
@@ -30,7 +30,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        add_slice_to_history_items(mongoDB)
+        update_scorecard_fields(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)
@@ -43,7 +43,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        add_slice_to_history_items(mongoDB)
+        update_scorecard_fields(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)

--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -283,7 +283,8 @@ class Scorecard:
         self.relooks = 0
         self.not_moving_toward_object = 0
         self.is_fastest_path = None
-        self.tool_usage = 0
+        self.ramp_actions = None
+        self.tool_usage = None
         self.correct_platform_side = None
         self.correct_door_opened = None
         self.pickup_not_pickupable = 0

--- a/scripts/_0_5_6_update_scorecard_fields.py
+++ b/scripts/_0_5_6_update_scorecard_fields.py
@@ -31,7 +31,7 @@ def update_scorecard_fields(mongoDB):
     # field for $rename must not be on the same path" error
     result = results_collection.update_many(
     {
-        "score.scorecard.repeat_failed": {"$exists": True}
+        "score.scorecard.open_unopenable": {"$exists": True}
     }, {
         "$rename": {'score.scorecard.open_unopenable': 'temp_unopen'}
     }, False)

--- a/scripts/_0_5_6_update_scorecard_fields.py
+++ b/scripts/_0_5_6_update_scorecard_fields.py
@@ -1,0 +1,34 @@
+def update_scorecard_fields(mongoDB):
+    results_collection = mongoDB["eval_4_results"]
+
+    result = results_collection.update_many(
+    {
+        "score.scorecard.multiple_container_look": {"$exists": True}
+    }, {
+        "$rename": {'score.scorecard.multiple_container_look': 'score.scorecard.container_relook'}
+    }, False)
+
+    print("update_many performed on " + str(
+        result.matched_count) + " documents")
+
+    # need to rename temporarily first to avoid "The source and target 
+    # field for $rename must not be on the same path" error
+    result = results_collection.update_many(
+    {
+        "score.scorecard.repeat_failed": {"$exists": True}
+    }, {
+        "$rename": {'score.scorecard.repeat_failed': 'temp_repeat'}
+    }, False)
+
+    result = results_collection.update_many(
+    {
+        "temp_repeat": {"$exists": True}
+    }, {
+        "$rename": {'temp_repeat': 'score.scorecard.repeat_failed.total_repeat_failed'}
+    }, False)
+
+    print("update_many performed on " + str(
+        result.matched_count) + " documents")
+
+
+    print("Updated scorecard fields from Eval 4.")

--- a/scripts/_0_5_6_update_scorecard_fields.py
+++ b/scripts/_0_5_6_update_scorecard_fields.py
@@ -27,6 +27,23 @@ def update_scorecard_fields(mongoDB):
         "$rename": {'temp_repeat': 'score.scorecard.repeat_failed.total_repeat_failed'}
     }, False)
 
+    # need to rename temporarily first to avoid "The source and target 
+    # field for $rename must not be on the same path" error
+    result = results_collection.update_many(
+    {
+        "score.scorecard.repeat_failed": {"$exists": True}
+    }, {
+        "$rename": {'score.scorecard.open_unopenable': 'temp_unopen'}
+    }, False)
+
+    result = results_collection.update_many(
+    {
+        "temp_unopen": {"$exists": True}
+    }, {
+        "$rename": {'temp_unopen': 'score.scorecard.open_unopenable.total_unopenable_attempts'}
+    }, False)
+
+
     print("update_many performed on " + str(
         result.matched_count) + " documents")
 


### PR DESCRIPTION
This was to check how the current scorecard code on development is looking/displayed in the UI. Looks like there's another open PR for an additional field, I can double check that one once its merged. 

Have a script to rename a few fields for eval 4 data to match up with their eval 5 counterparts for ease of doing the $sum calculations in the UI:

- 'score.scorecard.multiple_container_look' became 'score.scorecard.container_relook'
- 'score.scorecard.repeat_failed' is now 'score.scorecard.repeat_failed.total_repeat_failed' 
- 'score.scorecard.open_unopenable' is now 'score.scorecard.open_unopenable.total_unopenable_attempts' 

The last two are now nested because the failed objectIds are added for Eval 5+.

Here's how the scorecard object looks:
        "scorecard": {
            "repeat_failed": {
                "total_repeat_failed": 1,
                "someObjectId": 1
            },
            "attempt_impossible": 0,
            "correct_door_opened": null,   # would be t/f if applicable
            "correct_platform_side": null, # would be t/f if applicable
            "open_unopenable": {
                "total_unopenable_attempts": 3,
                "someObjectId1": 1,
                "someObjectId2": 2
            },
            "container_relook": 0,
            "not_moving_toward_object": 0,
            "revisits": 0,
            "fastest_path": null, # would be t/f if applicable
            "ramp_actions": {
                "went_up": 0,
                "went_down": 0,
                "went_up_abandoned": 0,
                "went_down_abandoned": 0,
                "ramp_fell_off": 0
            },
            "tool_usage": {
                "PushObject_failed": 2
            },
            "pickup_not_pickupable": 0,
            "interact_with_non_agent": 0
        }