### PR TITLE
MCS-1135:  If multi retrieval do not scorecard 'not moving towards target'

### DIFF
--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -570,11 +570,11 @@ class Scorecard:
         """Calculate number of times that the agent
         did not move toward the target"""
 
-        self.not_moving_toward_object = 0
-
         if(self.scene["goal"]["sceneInfo"]["secondaryType"] ==
                 MULTI_RETRIEVAL):
-            return self.not_moving_toward_object
+            return 0
+
+        self.not_moving_toward_object = 0
 
         seen_count = -1
         steps_not_moving_towards = 0

--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -72,6 +72,8 @@ DEFAULT_ROOM_DIMENSIONS = {'x': 10, 'y': 3, 'z': 10}
 PERFORMER_WIDTH = 0.25
 PERFORMER_HEIGHT = 0.762
 
+MULTI_RETRIEVAL = "multi retrieval"
+
 
 def get_relevant_object(output) -> str:
     """See if there is an object for the current action output"""
@@ -569,6 +571,10 @@ class Scorecard:
         did not move toward the target"""
 
         self.not_moving_toward_object = 0
+
+        if(self.scene["goal"]["sceneInfo"]["secondaryType"] ==
+                MULTI_RETRIEVAL):
+            return self.not_moving_toward_object
 
         seen_count = -1
         steps_not_moving_towards = 0

--- a/tests/test_data/golf_0018_15_debug.json
+++ b/tests/test_data/golf_0018_15_debug.json
@@ -394,7 +394,10 @@
       }
     },
     "description": "Find and pick up the small light grey metal trophy.",
-    "last_step": 10000
+    "last_step": 10000,
+    "sceneInfo": {
+      "secondaryType": "retrieval"
+    }
   },
   "evaluationOnly": true,
   "sequenceNumber": 18,

--- a/tests/test_data/india_0003_17_debug.json
+++ b/tests/test_data/india_0003_17_debug.json
@@ -209,7 +209,10 @@
       }
     },
     "description": "Find and pick up the small light grey metal trophy.",
-    "last_step": 10000
+    "last_step": 10000,
+    "sceneInfo": {
+      "secondaryType": "retrieval"
+    }
   },
   "evaluationOnly": false,
   "sequenceNumber": 3,

--- a/tests/test_data/ramps_eval_5_ex_1.json
+++ b/tests/test_data/ramps_eval_5_ex_1.json
@@ -27,7 +27,10 @@
       }
     },
     "description": "Find and pick up the tiny light black white rubber ball.",
-    "last_step": 2500
+    "last_step": 2500,
+    "sceneInfo": {
+      "secondaryType": "retrieval"
+    }
   },
   "objects": [
     {

--- a/tests/test_data/tool_use_eval_5_ex_1.json
+++ b/tests/test_data/tool_use_eval_5_ex_1.json
@@ -53,7 +53,10 @@
             }
         },
         "description": "Find and pick up the tiny light black white rubber ball.",
-        "last_step": 2500
+        "last_step": 2500,
+        "sceneInfo": {
+          "secondaryType": "retrieval"
+        }
     },
     "objects": [{
         "id": "target",


### PR DESCRIPTION
For multi retrieval we do not want to do any score card calculations for 'not moving towards target'.  Checked the rest of the score card variables and they should work as designed.