### PR TITLE
MCS-1684 - Fix incorrect path to docker.sock in ingest unit tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ python local_history_ingest.py --folder ../MCS/SCENE_HISTORY/
 
 To run the unit tests, run the command: `python -m unittest`
 
+You may get connection errors depending on how docker is installed on your machine, in which case, you should be able to do the following:
+`docker info && docker context ls` to confirm your current docker context and see their endpoints:
+```bash
+Client:
+ Context:    desktop-linux
+ Debug Mode: false
+ Plugins:
+  buildx: Docker Buildx (Docker Inc., v0.10.0)
+ ....
+
+NAME                TYPE             DESCRIPTION                        DOCKER ENDPOINT
+default             moby             Current DOCKER_HOST based          unix:///var/run/docker.sock
+                                      configuration
+desktop-linux *     moby                                                unix:///somepath/.docker/run/docker.sock
+```
+In this case, the DOCKER_HOST environment variable needs to be set to the endpoint specified in the active context:
+`export DOCKER_HOST=unix:///somepath/.docker/run/docker.sock`
+
+
 ### Notes
 
 - Some unit tests will start a MongoDB instance in a docker container, and then stop it once the tests are done. Each time you run the unit tests, python will automatically download the latest `mongo` docker image, if needed.

--- a/README.md
+++ b/README.md
@@ -58,23 +58,7 @@ python local_history_ingest.py --folder ../MCS/SCENE_HISTORY/
 
 To run the unit tests, run the command: `python -m unittest`
 
-You may get connection errors depending on how docker is installed on your machine, in which case, you should be able to do the following:
-`docker info && docker context ls` to confirm your current docker context and see their endpoints:
-```bash
-Client:
- Context:    desktop-linux
- Debug Mode: false
- Plugins:
-  buildx: Docker Buildx (Docker Inc., v0.10.0)
- ....
-
-NAME                TYPE             DESCRIPTION                        DOCKER ENDPOINT
-default             moby             Current DOCKER_HOST based          unix:///var/run/docker.sock
-                                      configuration
-desktop-linux *     moby                                                unix:///somepath/.docker/run/docker.sock
-```
-In this case, the DOCKER_HOST environment variable needs to be set to the endpoint specified in the active context:
-`export DOCKER_HOST=unix:///somepath/.docker/run/docker.sock`
+You may get connection errors depending on how Docker is installed on your machine and whether or not your DOCKER_HOST environment variable is set. You should be able to unset it manually and allow the tests to set them programatically if needed. 
 
 
 ### Notes

--- a/tests/test_mcs_history_ingest.py
+++ b/tests/test_mcs_history_ingest.py
@@ -50,15 +50,17 @@ class TestMcsHistoryIngestMongo(unittest.TestCase):
     def setUpClass(cls):
         '''Start the mongo docker container'''
         # Get current context host value, attempt to set as DOCKER_HOST
-        docker_host = docker.context.ContextAPI.get_current_context().Host
+        docker_url = "unix://var/run/docker.sock"
         if os.environ.get('DOCKER_HOST') is None:
+            docker_host = docker.context.ContextAPI.get_current_context().Host
             os.environ["DOCKER_HOST"] = docker_host
+            docker_url = docker_host
 
         # connect to docker daemon
         cls.docker_client = docker.from_env()
         # create low-level API client for health checks
         cls.api_client = docker.APIClient(
-            base_url=docker_host)
+            base_url=docker_url)
         cls.mongo_container = cls.create_mongo_container(
             cls.docker_client,
             cls.api_client)

--- a/tests/test_mcs_history_ingest.py
+++ b/tests/test_mcs_history_ingest.py
@@ -1,4 +1,5 @@
 from enum import auto
+import os
 import time
 import unittest
 import warnings
@@ -48,11 +49,16 @@ class TestMcsHistoryIngestMongo(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         '''Start the mongo docker container'''
+        # Get current context host value, attempt to set as DOCKER_HOST
+        docker_host = docker.context.ContextAPI.get_current_context().Host
+        if os.environ.get('DOCKER_HOST') is None:
+            os.environ["DOCKER_HOST"] = docker_host
+
         # connect to docker daemon
         cls.docker_client = docker.from_env()
         # create low-level API client for health checks
         cls.api_client = docker.APIClient(
-            base_url="unix://var/run/docker.sock")
+            base_url=docker_host)
         cls.mongo_container = cls.create_mongo_container(
             cls.docker_client,
             cls.api_client)

--- a/tests/test_mcs_history_ingest.py
+++ b/tests/test_mcs_history_ingest.py
@@ -22,6 +22,7 @@ class TestMcsHistoryIngestMongo(unittest.TestCase):
 
     mongo_client = None
     mongo_host_port = 27027
+    os_environ_none = False
 
     @classmethod
     def create_mongo_container(cls, docker_client, api_client, timeout=60):
@@ -55,6 +56,7 @@ class TestMcsHistoryIngestMongo(unittest.TestCase):
             docker_host = docker.context.ContextAPI.get_current_context().Host
             os.environ["DOCKER_HOST"] = docker_host
             docker_url = docker_host
+            cls.os_environ_none = True
 
         # connect to docker daemon
         cls.docker_client = docker.from_env()
@@ -72,6 +74,8 @@ class TestMcsHistoryIngestMongo(unittest.TestCase):
         cls.mongo_container.stop()
         cls.docker_client.close()
         cls.api_client.close()
+        if cls.os_environ_none:
+            os.environ.pop('DOCKER_HOST', None)
 
     def setUp(self):
         '''Create the client and insert a single document'''

--- a/tests/test_mcs_scene_ingest.py
+++ b/tests/test_mcs_scene_ingest.py
@@ -47,15 +47,18 @@ class TestMcsSceneIngestMongo(unittest.TestCase):
     def setUpClass(cls):
         '''Start the mongo docker container'''
         # Get current context host value, attempt to set as DOCKER_HOST
-        docker_host = docker.context.ContextAPI.get_current_context().Host
+        docker_url = "unix://var/run/docker.sock"
         if os.environ.get('DOCKER_HOST') is None:
+            print("DOCKER HOST WAS NONE")
+            docker_host = docker.context.ContextAPI.get_current_context().Host
             os.environ["DOCKER_HOST"] = docker_host
+            docker_url = docker_host
 
         # connect to docker daemon
         cls.docker_client = docker.from_env()
         # create low-level API client for health checks
         cls.api_client = docker.APIClient(
-            base_url=docker_host)
+            base_url=docker_url)
         cls.mongo_container = cls.create_mongo_container(
             cls.docker_client,
             cls.api_client)

--- a/tests/test_mcs_scene_ingest.py
+++ b/tests/test_mcs_scene_ingest.py
@@ -1,5 +1,6 @@
 import docker
 import logging
+import os
 import time
 import unittest
 import warnings
@@ -45,11 +46,16 @@ class TestMcsSceneIngestMongo(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         '''Start the mongo docker container'''
+        # Get current context host value, attempt to set as DOCKER_HOST
+        docker_host = docker.context.ContextAPI.get_current_context().Host
+        if os.environ.get('DOCKER_HOST') is None:
+            os.environ["DOCKER_HOST"] = docker_host
+
         # connect to docker daemon
         cls.docker_client = docker.from_env()
         # create low-level API client for health checks
         cls.api_client = docker.APIClient(
-            base_url="unix://var/run/docker.sock")
+            base_url=docker_host)
         cls.mongo_container = cls.create_mongo_container(
             cls.docker_client,
             cls.api_client)

--- a/tests/test_mcs_scene_ingest.py
+++ b/tests/test_mcs_scene_ingest.py
@@ -19,6 +19,7 @@ class TestMcsSceneIngestMongo(unittest.TestCase):
 
     mongo_client = None
     mongo_host_port = 27027
+    os_environ_none = False
 
     @classmethod
     def create_mongo_container(cls, docker_client, api_client, timeout=60):
@@ -53,6 +54,7 @@ class TestMcsSceneIngestMongo(unittest.TestCase):
             docker_host = docker.context.ContextAPI.get_current_context().Host
             os.environ["DOCKER_HOST"] = docker_host
             docker_url = docker_host
+            cls.os_environ_none = True
 
         # connect to docker daemon
         cls.docker_client = docker.from_env()
@@ -70,6 +72,8 @@ class TestMcsSceneIngestMongo(unittest.TestCase):
         cls.mongo_container.stop()
         cls.docker_client.close()
         cls.api_client.close()
+        if cls.os_environ_none:
+            os.environ.pop('DOCKER_HOST', None)
 
     def setUp(self):
         '''Create the client and insert a single document'''


### PR DESCRIPTION
Was having docker connection issues in the updated test files in this PR -- I think this is due to permissions issues with Docker on my new Mac (+ we can't use sudo, which I think Docker Desktop tries to do to symlink the path to /var/run/docker.sock). I tried to handle things programmatically while also leaving instructions in the README if for whatever reason that fails. For non-Mac users, please let me know if this works for you or if there are issues with it. Also doesn't hurt for another Mac user to test as well, since I think Brian and I were getting different results. Thanks!

See notes/context here: https://nextcentury.atlassian.net/browse/MCS-1684