### PR TITLE
Fix correct_platform_side for scorecard (MCS-1713).

### DIFF
--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -922,7 +922,7 @@ class Scorecard:
         # Does this scene have a targetSide? If not, return
         # correct_platform_side (currently set to None).
         goal = self.scene.get('goal')
-        if 'sceneInfo' in goal and 'targetSide' in goal['sceneInfo']:
+        if ('sceneInfo' in goal and 'targetSide' in goal['sceneInfo'] and goal['sceneInfo']['targetSide'] is not None):
             target_side = goal['sceneInfo']['targetSide']
         else:
             return self.correct_platform_side

--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -919,10 +919,11 @@ class Scorecard:
               negative X being "left" and positive X being "right"
         '''
 
-        # Does this scene have a targetSide? If not, return
+        # Does this scene have a clear targetSide? If not, return
         # correct_platform_side (currently set to None).
         goal = self.scene.get('goal')
-        if ('sceneInfo' in goal and 'targetSide' in goal['sceneInfo'] and goal['sceneInfo']['targetSide'] is not None):
+        if ('sceneInfo' in goal and 'targetSide' in goal['sceneInfo'] and
+                goal['sceneInfo']['targetSide'] in ['left', 'right']):
             target_side = goal['sceneInfo']['targetSide']
         else:
             return self.correct_platform_side


### PR DESCRIPTION
When I was checking if this was fixed with Thomas' patch for the Python API, realized there was still a small issue here. Sometimes the targetSide tag exists in a scene but is null, so wanted to make sure we aren't calculating it for non-applicable scenes. 