### PR TITLE
MCS-1764:  Script to rerun paired scoring for Evaluation 6

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,11 +1,11 @@
 from pymongo import MongoClient
-from scripts._0_6_5_2_apply_correct_weighted_scores import apply_correct_weighted_scores
+from scripts._0_6_5_3_fix_agent_pair_scoring import rescore_passive_agents
 # We might want to move mongo user/pass to new file
 VERSION_COLLECTION = "mcs_version"
 
 # Change this version if running a new deploy script
 # Make sure the first two numbers match the current MCS API Release
-db_version = "0.6.5.2"
+db_version = "0.6.5.3"
 
 
 def check_version(mongoDB):
@@ -29,7 +29,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        apply_correct_weighted_scores(mongoDB)
+        rescore_passive_agents(mongoDB, client, 'mcs')
 
         # Now update db version
         update_db_version(mongoDB)
@@ -42,7 +42,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        apply_correct_weighted_scores(mongoDB)
+        rescore_passive_agents(mongoDB, client, 'dev')
 
         # Now update db version
         update_db_version(mongoDB)

--- a/scripts/_0_6_5_3_fix_agent_pair_scoring.py
+++ b/scripts/_0_6_5_3_fix_agent_pair_scoring.py
@@ -1,0 +1,27 @@
+import mcs_history_ingest
+
+def rescore_passive_agents(mongoDB, client, db_string):
+    results_collection = mongoDB["eval_6_results"]
+    scenes_collection = mongoDB["eval_6_scenes"]
+
+    # This will only get NYU agent tasks, "seeing leads to knowing" has
+    #   a test_type of "passive" 
+    history_files = results_collection.find({"test_type": "agents"})
+
+    for history_record in history_files:
+        paired_record = mcs_history_ingest.return_agency_paired_history_item(
+                    client, db_string, history_record)
+
+        if paired_record:
+            # Determine which pair item is correct (1), the correct pair
+            #   item should have a higher classification to be correct
+            if paired_record["score"]["ground_truth"] == 1:
+                mcs_history_ingest.update_agency_scoring(paired_record, history_record)
+            else:
+                mcs_history_ingest.update_agency_scoring(history_record, paired_record)
+
+            mcs_history_ingest.update_agency_paired_history_item(
+                client, db_string, paired_record)
+
+        results_collection.replace_one({"_id": history_record["_id"]}, history_record)
+        


### PR DESCRIPTION
Here is what the UI looks like after running the script.  Everything is more in line with what we would expect:  (NOTE:  Most of the code in this script is just copied from history_ingest to be reran here.

![Screenshot 2023-04-19 at 12 28 47 PM](https://user-images.githubusercontent.com/13155972/233140507-93a2f2ab-aa6a-4ca8-a5f6-fe8edc590472.png)
