### PR TITLE
MCS-1765:  Update Shape Constancy Weights for Eval 6

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,11 +1,11 @@
 from pymongo import MongoClient
-from scripts._0_6_5_3_fix_agent_pair_scoring import rescore_passive_agents
+from scripts._0_6_5_4_fix_shape_constancy_weight import correct_shape_constancy_weights
 # We might want to move mongo user/pass to new file
 VERSION_COLLECTION = "mcs_version"
 
 # Change this version if running a new deploy script
 # Make sure the first two numbers match the current MCS API Release
-db_version = "0.6.5.3"
+db_version = "0.6.5.4"
 
 
 def check_version(mongoDB):
@@ -29,7 +29,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        rescore_passive_agents(mongoDB, client, 'mcs')
+        correct_shape_constancy_weights(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)
@@ -42,7 +42,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        rescore_passive_agents(mongoDB, client, 'dev')
+        correct_shape_constancy_weights(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)

--- a/mcs_history_ingest.py
+++ b/mcs_history_ingest.py
@@ -53,8 +53,6 @@ EVAL_HIST_MAPPING_DICT = {
 
 # Weight from Design, some plausible scenes are worth more,
 #   because there aren't as many as the implausible ones
-SHAPE_CONSTANCY_DUPLICATE_CUBE = ["A1", "B1"]
-SHAPE_CONSTANCY_8X_CUBE = ["A2", "B2", "C2", "D2"]
 PASSIVE_OBJ_PERM_DUPLICATE_CUBE = ["G3", "H3", "I3"]
 SEEING_LEADS_KNOWING_3X_CUBE = ["A1", "F1"]
 
@@ -67,6 +65,7 @@ PASSING_CELLS = {
     "agent identification": ["A1", "B1", "C1", "E1", "F1",
                              "G1", "A2", "B2", "C2", "E2",
                              "F2", "G2"],
+    "shape constancy": ["A1", "A2", "B1", "D2", "E1", "E3", "J1", "L4"],
     "spatial elimination": ["A1", "A2"],
     "moving target prediction": ["A1", "B1", "E1", "F1", "I1", "J1"],
     "holes": ["B1", "C1", "E1", "F1", "B2", "C2", "E2", "F2"],
@@ -567,12 +566,7 @@ def calculate_weighted_confidence(history_item: dict, multiplier: int) -> Union[
 
 def add_weighted_cube_scoring(history_item: dict, scene: dict) -> tuple:
     if "goal" in scene and "sceneInfo" in scene["goal"]:
-        if scene["goal"]["sceneInfo"]["tertiaryType"] == "shape constancy":
-            if history_item["scene_goal_id"] in SHAPE_CONSTANCY_DUPLICATE_CUBE:
-                return (history_item["score"]["score"] * 2, 2, calculate_weighted_confidence(history_item, 2))
-            elif history_item["scene_goal_id"] in SHAPE_CONSTANCY_8X_CUBE:
-                return (history_item["score"]["score"] * 8, 8, calculate_weighted_confidence(history_item, 8))
-        elif scene["goal"]["sceneInfo"]["tertiaryType"] == "object permanence":
+        if scene["goal"]["sceneInfo"]["tertiaryType"] == "object permanence":
             if history_item["scene_goal_id"] in PASSIVE_OBJ_PERM_DUPLICATE_CUBE:
                 return (history_item["score"]["score"] * 2, 2, calculate_weighted_confidence(history_item, 2))
         elif scene["goal"]["sceneInfo"]["tertiaryType"] == "seeing leads to knowing":

--- a/scripts/_0_6_5_4_fix_shape_constancy_weight.py
+++ b/scripts/_0_6_5_4_fix_shape_constancy_weight.py
@@ -4,8 +4,6 @@ def correct_shape_constancy_weights(mongoDB):
     results_collection = mongoDB["eval_6_results"]
     scenes_collection = mongoDB["eval_6_scenes"]
 
-    # This will only get NYU agent tasks, "seeing leads to knowing" has
-    #   a test_type of "passive" 
     history_files = results_collection.find({"category_type": "shape constancy"})
 
     for history in history_files:

--- a/scripts/_0_6_5_4_fix_shape_constancy_weight.py
+++ b/scripts/_0_6_5_4_fix_shape_constancy_weight.py
@@ -1,0 +1,24 @@
+import mcs_history_ingest
+
+def correct_shape_constancy_weights(mongoDB):
+    results_collection = mongoDB["eval_6_results"]
+    scenes_collection = mongoDB["eval_6_scenes"]
+
+    # This will only get NYU agent tasks, "seeing leads to knowing" has
+    #   a test_type of "passive" 
+    history_files = results_collection.find({"category_type": "shape constancy"})
+
+    for history in history_files:
+        scene = scenes_collection.find_one({"name": history["name"]})
+
+        (
+            weighted_score,
+            weighted_score_worth,
+            weighted_confidence
+        ) = mcs_history_ingest.add_weighted_cube_scoring(history, scene)
+
+        history["score"]["weighted_score"] = weighted_score
+        history["score"]["weighted_score_worth"] = weighted_score_worth
+        history["score"]["weighted_confidence"] = weighted_confidence
+
+        results_collection.replace_one({"_id": history["_id"]}, history)


### PR DESCRIPTION
You can see the weights make sense now as there are 500 unweighted, and 400 weighted scenes, as we are exluding 1/5 of the total cells.

Weights before the script:
![Screenshot 2023-04-19 at 12 39 17 PM](https://user-images.githubusercontent.com/13155972/233143788-09b7cb9a-504b-436b-8b37-79ff939580c3.png)

Weights after the script:
![Screenshot 2023-04-19 at 12 42 26 PM](https://user-images.githubusercontent.com/13155972/233143831-5a521a10-737f-425b-b081-9d939bce30db.png)
