### PR TITLE
MCS-1804 - Add first step information for performer + target start positions to csv

### DIFF
--- a/create_collection_keys.py
+++ b/create_collection_keys.py
@@ -1,5 +1,17 @@
 import re
 
+# For the following step array fields, we want to save the 
+# value contained in the first step.
+STEPS_OUTPUT_FIELDS_TO_SAVE = [
+    "steps.output.position.x",
+    "steps.output.position.y",
+    "steps.output.position.z",
+    "steps.output.rotation",
+    "steps.output.target.position.x",
+    "steps.output.target.position.y",
+    "steps.output.target.position.z"
+]
+
 # Added check for '-' for dash because some scorecard fields have object ids, same for
 #  the numerical check.  None of our regular fields have '-' or numbers.
 def recursive_find_keys(x, keys, append_string):
@@ -14,11 +26,19 @@ def recursive_find_keys(x, keys, append_string):
                         arrayItem, keys, append_string + item + ".")
                 elif append_string + item not in keys and "-" not in (append_string + item) \
                          and not bool(re.search(r'\d', (append_string + item))):
-                    keys.append(append_string + item)
+                    append_key(append_string + item, keys)
+
         elif append_string + item not in keys and "-" not in (append_string + item) \
                 and not bool(re.search(r'\d', (append_string + item))):
-            keys.append(append_string + item)
+            append_key(append_string + item, keys)
 
+def append_key(key_string, keys):
+    if(key_string.startswith("steps.") is False):
+        keys.append(key_string)
+    elif key_string in STEPS_OUTPUT_FIELDS_TO_SAVE:
+        key_string = key_string[:6] + "0." + key_string[6:]
+        if(key_string not in keys):
+            keys.append(key_string)
 
 def find_collection_keys(index: str, collection_name: str, mongoDB):
     collection = mongoDB[index]


### PR DESCRIPTION
If approved, will also have to run update_collection_keys_if_missing.py for this + regenerate the results csv. 

What I ended up doing was just omitting most "steps." keys, since mongoexport isn't saving that array anyway, and am explicitly saving the first step for the fields specified in the ticket like so:
    'steps.0.output.position.x',
    'steps.0.output.position.y',
    'steps.0.output.position.z',
    'steps.0.output.rotation',
    'steps.0.output.target.position.x',
    'steps.0.output.target.position.y',
    'steps.0.output.target.position.z',

Let me know if that makes sense. 