### PR TITLE
Mcs 1827 exclude opics imitation

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -12,7 +12,8 @@ def check_version(mongoDB):
     collection = mongoDB[VERSION_COLLECTION]
     version_obj = collection.find_one()
     # return true if it is a newer db version
-    return db_version > version_obj['version']
+    return True
+    # return db_version > version_obj['version']
 
 
 def update_db_version(mongoDB):
@@ -42,7 +43,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        rescore_agents_imitation(mongoDB, client, "dev")
+        rescore_opics_imitation_task(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)

--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,11 +1,11 @@
 from pymongo import MongoClient
-from scripts._0_6_5_6_fix_agent_scoring_wrong_ground_truth import rescore_agents_imitation
+from scripts._0_6_5_7_exclude_opics_imitation import rescore_opics_imitation_task
 # We might want to move mongo user/pass to new file
 VERSION_COLLECTION = "mcs_version"
 
 # Change this version if running a new deploy script
 # Make sure the first two numbers match the current MCS API Release
-db_version = "0.6.5.6"
+db_version = "0.6.5.7"
 
 
 def check_version(mongoDB):
@@ -29,7 +29,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        rescore_agents_imitation(mongoDB, client, "mcs")
+        rescore_opics_imitation_task(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)

--- a/deployment_script.py
+++ b/deployment_script.py
@@ -12,8 +12,7 @@ def check_version(mongoDB):
     collection = mongoDB[VERSION_COLLECTION]
     version_obj = collection.find_one()
     # return true if it is a newer db version
-    return True
-    # return db_version > version_obj['version']
+    return db_version > version_obj['version']
 
 
 def update_db_version(mongoDB):

--- a/scripts/_0_6_5_7_exclude_opics_imitation.py
+++ b/scripts/_0_6_5_7_exclude_opics_imitation.py
@@ -55,9 +55,11 @@ def rescore_opics_imitation_task(mongoDB):
     print("Begin looping through scene file names.")
 
     for history_file_name in scene_file_names:
-        history_files = results_collection.find({"category_type": "agents imitation", "performer": "OPICS", "name": history_file_name})
 
-        result = history_files.update_many(
+        result = results_collection.update_many(
+            {
+                "category_type": "imitation task", "performer": "OPICS", "name": history_file_name
+            },             
             [{
                 "$set": {
                     'score.weighted_score': 0,

--- a/scripts/_0_6_5_7_exclude_opics_imitation.py
+++ b/scripts/_0_6_5_7_exclude_opics_imitation.py
@@ -1,0 +1,68 @@
+# OPICS was able to retrieve ball from ceiling 
+# This patch rescores their imitation task where ball was retrieved from ceiling
+# weighted_score and weighted_score_worth are set to 0
+
+
+import mcs_history_ingest
+
+scene_file_names = ["foxtrot_0002_03",
+    "foxtrot_0002_06",
+    "foxtrot_0002_09",
+    "foxtrot_0002_10",
+    "foxtrot_0002_12",
+    "foxtrot_0003_03",
+    "foxtrot_0003_08",
+    "foxtrot_0004_01",
+    "foxtrot_0004_12",
+    "foxtrot_0005_02",
+    "foxtrot_0005_06",
+    "foxtrot_0005_08",
+    "foxtrot_0005_09",
+    "foxtrot_0006_06",
+    "foxtrot_0006_08",
+    "foxtrot_0006_10",
+    "foxtrot_0006_11",
+    "foxtrot_0007_03",
+    "foxtrot_0007_07",
+    "foxtrot_0007_11",
+    "foxtrot_0007_12",
+    "foxtrot_0009_07",
+    "foxtrot_0009_09",
+    "foxtrot_0012_06",
+    "foxtrot_0012_08",
+    "foxtrot_0013_01",
+    "foxtrot_0017_02",
+    "foxtrot_0017_12",
+    "foxtrot_0018_02",
+    "foxtrot_0018_04",
+    "foxtrot_0019_01",
+    "foxtrot_0019_02",
+    "foxtrot_0019_09",
+    "foxtrot_0019_12",
+    "foxtrot_0020_02",
+    "foxtrot_0020_03",
+    "foxtrot_0021_09",
+    "foxtrot_0024_02",
+    "foxtrot_0024_06",
+    "foxtrot_0024_07",
+    "foxtrot_0024_08",
+    "foxtrot_0024_10",
+    "foxtrot_0024_11"]
+
+def rescore_opics_imitation_task(mongoDB):
+    results_collection = mongoDB["eval_6_results"]
+
+    print("Begin looping through scene file names.")
+
+    for history_file_name in scene_file_names:
+        history_files = results_collection.find({"category_type": "agents imitation", "performer": "OPICS", "name": history_file_name})
+
+        result = history_files.update_many(
+            [{
+                "$set": {
+                    'score.weighted_score': 0,
+                    'score.weighted_score_worth': 0
+                }
+            }])
+
+        print("Update " + history_file_name + ".", result)    


### PR DESCRIPTION
Excludes scenes from UI score where OPICS retrieves the soccer ball from the ceiling.  

Set 'score.weighted_score' and 'score.weighted_score_worth' to 0 for  performer = OPICS and category_type = "imitation task" when scene files ("name") was one of the affected scenes. Reviewed the rest of the scores against prod and looks like nothing else was affected.

Rebuilt my local UI with just Eval 6 (mcs-ui) and started local containers, then in mcs-ingest run `python deployment_script.py`

Before:
![image](https://github.com/NextCenturyCorporation/mcs-ingest/assets/62263242/c4639a72-22e8-461e-8081-5699cb8b5a8d)


After:
![image](https://github.com/NextCenturyCorporation/mcs-ingest/assets/62263242/6ae1ae3b-9e6f-4bba-9f7e-a143a3dd88fb)
