### PR TITLE
MCS-1912 - correct scorecard variables for trajectory and interactive collisions

### DIFF
--- a/deployment_script.py
+++ b/deployment_script.py
@@ -1,11 +1,11 @@
 from pymongo import MongoClient
-from scripts._0_6_5_7_exclude_opics_imitation import rescore_opics_imitation_task
+from scripts._0_7_0_int_collisions_trajectory_scorecard import update_int_collisions_trajectory_scorecard
 # We might want to move mongo user/pass to new file
 VERSION_COLLECTION = "mcs_version"
 
 # Change this version if running a new deploy script
 # Make sure the first two numbers match the current MCS API Release
-db_version = "0.6.5.7"
+db_version = "0.7.0"
 
 
 def check_version(mongoDB):
@@ -29,7 +29,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        rescore_opics_imitation_task(mongoDB)
+        update_int_collisions_trajectory_scorecard(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)
@@ -42,7 +42,7 @@ def main():
     if(check_version(mongoDB)):
         print("New db version, execute scripts")
         # Place scripts here to run
-        rescore_opics_imitation_task(mongoDB)
+        update_int_collisions_trajectory_scorecard(mongoDB)
 
         # Now update db version
         update_db_version(mongoDB)

--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -981,7 +981,9 @@ class Scorecard:
             target_side = goal['sceneInfo']['toolChoiceValidSide']
         elif (
             'sceneInfo' in goal and 'relation' in goal['sceneInfo'] and
-            goal['sceneInfo']['relation'] in ['sameSide', 'oppositeSide']
+            goal['sceneInfo']['relation'] in ['sameSide', 'oppositeSide'] and
+            'type' in goal['sceneInfo'] and
+            goal['sceneInfo']['type'] in ['collision', 'noCollision']
         ):
 
             # Support for Eval 6 Interactive Collisions
@@ -994,9 +996,11 @@ class Scorecard:
                 return self.correct_platform_side
 
             relation = goal['sceneInfo']['relation']
+            collision = goal['sceneInfo']['type']
             x_pos = throwing_device[0]['shows'][0]['position']['x']
 
-            if relation == 'sameSide':
+            isSameSide = relation == 'sameSide' and collision == 'noCollision'
+            if isSameSide:
                 target_side = 'left' if x_pos < 0 else 'right'
             else:
                 target_side = 'right' if x_pos < 0 else 'left'
@@ -1055,7 +1059,9 @@ class Scorecard:
             correct_door = goal['sceneInfo']['correctDoor']
         elif (
             'sceneInfo' in goal and 'relation' in goal['sceneInfo'] and
-            goal['sceneInfo']['relation'] in ['sameSide', 'oppositeSide']
+            goal['sceneInfo']['relation'] in ['sameSide', 'oppositeSide'] and
+            'type' in goal['sceneInfo'] and
+            goal['sceneInfo']['type'] in ['collision', 'noCollision']
         ):
             # Support for Eval 6 Interactive Collisions
             throwing_device = [obj for obj in self.scene['objects']
@@ -1067,9 +1073,11 @@ class Scorecard:
                 return self.correct_door_opened
 
             relation = goal['sceneInfo']['relation']
+            collision = goal['sceneInfo']['type']
             x_pos = throwing_device[0]['shows'][0]['position']['x']
 
-            if relation == 'sameSide':
+            isSameSide = relation == 'sameSide' and collision == 'noCollision'
+            if isSameSide:
                 correct_door = 'left' if x_pos < 0 else 'right'
             else:
                 correct_door = 'right' if x_pos < 0 else 'left'

--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -999,8 +999,8 @@ class Scorecard:
             collision = goal['sceneInfo']['type']
             x_pos = throwing_device[0]['shows'][0]['position']['x']
 
-            isSameSide = relation == 'sameSide' and collision == 'noCollision'
-            if isSameSide:
+            is_target_same_side = relation == 'sameSide' and collision == 'noCollision'
+            if is_target_same_side:
                 target_side = 'left' if x_pos < 0 else 'right'
             else:
                 target_side = 'right' if x_pos < 0 else 'left'
@@ -1076,8 +1076,8 @@ class Scorecard:
             collision = goal['sceneInfo']['type']
             x_pos = throwing_device[0]['shows'][0]['position']['x']
 
-            isSameSide = relation == 'sameSide' and collision == 'noCollision'
-            if isSameSide:
+            is_target_same_side = relation == 'sameSide' and collision == 'noCollision'
+            if is_target_same_side:
                 correct_door = 'left' if x_pos < 0 else 'right'
             else:
                 correct_door = 'right' if x_pos < 0 else 'left'

--- a/scorecard/scorecard.py
+++ b/scorecard/scorecard.py
@@ -443,6 +443,9 @@ class Scorecard:
     def get_correct_platform_side(self):
         return self.correct_platform_side
 
+    def get_correct_door_opened(self):
+        return self.correct_door_opened
+
     def calc_revisiting(self):
 
         steps_list = self.history['steps']
@@ -976,6 +979,35 @@ class Scorecard:
         ):
             # Support Eval 6 Tool Choice scenes.
             target_side = goal['sceneInfo']['toolChoiceValidSide']
+        elif (
+            'sceneInfo' in goal and 'relation' in goal['sceneInfo'] and
+            goal['sceneInfo']['relation'] in ['sameSide', 'oppositeSide']
+        ):
+
+            # Support for Eval 6 Interactive Collisions
+            throwing_device = [obj for obj in self.scene['objects']
+                    if obj['id'].startswith('throwing_device_')]
+
+            # if for whatever reason, we can't find the
+            # throwing device, return
+            if len(throwing_device) == 0:
+                return self.correct_platform_side
+
+            relation = goal['sceneInfo']['relation']
+            x_pos = throwing_device[0]['shows'][0]['position']['x']
+
+            if relation == 'sameSide':
+                target_side = 'left' if x_pos < 0 else 'right'
+            else:
+                target_side = 'right' if x_pos < 0 else 'left'
+        elif (
+            'sceneInfo' in goal and 'finalRewardLocation' in goal['sceneInfo'] and
+            goal['sceneInfo']['finalRewardLocation'] in ['left', 'right']):
+
+            # Support for Eval 6 Trajectory Scenes
+            finalRewardLoc = goal['sceneInfo']['finalRewardLocation']
+
+            target_side = 'left' if finalRewardLoc == 'left' else 'right'
         else:
             return self.correct_platform_side
 
@@ -1018,8 +1050,38 @@ class Scorecard:
         # Does this scene have a correctDoor? If not, return
         # correct_door_opened (currently set to None).
         goal = self.scene.get('goal')
-        if 'sceneInfo' in goal and 'correctDoor' in goal['sceneInfo']:
+        if ('sceneInfo' in goal and 'correctDoor' in goal['sceneInfo'] and
+                goal['sceneInfo']['correctDoor'] is not None):
             correct_door = goal['sceneInfo']['correctDoor']
+        elif (
+            'sceneInfo' in goal and 'relation' in goal['sceneInfo'] and
+            goal['sceneInfo']['relation'] in ['sameSide', 'oppositeSide']
+        ):
+            # Support for Eval 6 Interactive Collisions
+            throwing_device = [obj for obj in self.scene['objects']
+                    if obj['id'].startswith('throwing_device_')]
+
+            # if for whatever reason, we can't find the
+            # throwing device, return
+            if len(throwing_device) == 0:
+                return self.correct_door_opened
+
+            relation = goal['sceneInfo']['relation']
+            x_pos = throwing_device[0]['shows'][0]['position']['x']
+
+            if relation == 'sameSide':
+                correct_door = 'left' if x_pos < 0 else 'right'
+            else:
+                correct_door = 'right' if x_pos < 0 else 'left'
+
+        elif (
+            'sceneInfo' in goal and 'finalRewardLocation' in goal['sceneInfo'] and
+            goal['sceneInfo']['finalRewardLocation'] in ['left', 'right']):
+
+            # Support for Eval 6 Trajectory Scenes
+            finalRewardLoc = goal['sceneInfo']['finalRewardLocation']
+
+            correct_door = 'left' if finalRewardLoc == 'left' else 'right'
         else:
             return self.correct_door_opened
 

--- a/scripts/_0_7_0_int_collisions_trajectory_scorecard.py
+++ b/scripts/_0_7_0_int_collisions_trajectory_scorecard.py
@@ -1,0 +1,48 @@
+from scorecard import Scorecard
+import boto3
+import os
+import json
+import io
+
+s3 = boto3.resource('s3')
+
+def load_json_file(file_name: str) -> dict:
+    with io.open(
+            file_name,
+            mode='r',
+            encoding='utf-8-sig') as json_file:
+        return json.loads(json_file.read())
+
+def update_int_collisions_trajectory_scorecard(mongoDB):
+    results_collection = mongoDB["eval_6_results"]
+    scenes_collection = mongoDB["eval_6_scenes"]
+
+    # Update the Scorecard for Interactive Collisions and Trajectory
+    category_types = ["interactive collision", "trajectory"]
+
+    history_files = results_collection.find({
+        "category_type": { "$in": category_types}
+    })
+    for history_record in history_files:
+        scene = scenes_collection.find_one({"name": history_record["name"]})
+        
+        # Download History file (the history record doesn't have everything we need
+        # to calculate correct_door_opened)
+        bucket = s3.Bucket("evaluation-images")
+        history_file = "eval-resources-6/" + history_record["fullFilename"] + ".json"
+        basename = history_record["fullFilename"] + ".json"
+        print(f"Downloading {basename}")
+        bucket.download_file(history_file, basename)
+
+        history_item = load_json_file(basename)
+        scorecard = Scorecard(history_item, scene)
+        scorecard.calc_correct_platform_side()
+        scorecard.calc_correct_door_opened()
+
+        history_record["score"]["scorecard"]["correct_platform_side"] = scorecard.get_correct_platform_side()
+        history_record["score"]["scorecard"]["correct_door_opened"] = scorecard.get_correct_door_opened()
+        results_collection.replace_one({"_id": history_record["_id"]}, history_record)
+        os.remove(basename)
+
+    print("Updated Interactive Collision and Trajectory Scorecard correct platform side and correct door opened")
+


### PR DESCRIPTION
Koleen initially mentioned correct_platform_side as being incorrect, realized that was also the case for correct_door_opened (all of the latter were set to false). 

Ran this locally, things looked correct for the results I checked. 